### PR TITLE
fix: findAll not accessing undefined 

### DIFF
--- a/libs/data-access/src/lib/infrastructure/schedule-storage.repository.impl.ts
+++ b/libs/data-access/src/lib/infrastructure/schedule-storage.repository.impl.ts
@@ -46,7 +46,7 @@ export class ScheduleStorageRepositoryImpl
   findAll() {
     let data = this.read();
 
-    const isOutdated = 'time' in data[0];
+    const isOutdated = 'time' in data;
 
     data = data.map(refactorSchedule);
 

--- a/libs/data-access/src/lib/infrastructure/team-storage.repository.impl.ts
+++ b/libs/data-access/src/lib/infrastructure/team-storage.repository.impl.ts
@@ -47,7 +47,7 @@ export class TeamStorageRepositoryImpl
   findAll() {
     let data = this.read();
 
-    const isOutdated = 'team' in data[0];
+    const isOutdated = 'team' in data;
 
     data = data.map(refactorTeam);
 


### PR DESCRIPTION
Two similar functions basically had the same behavior where they always tried to access the first item and it would crash if there was none. This bug would actually make it impossible to create the first item and it would permanently return undefined.